### PR TITLE
fix: resolve installation script reinstall issues

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,13 +29,13 @@ irm https://raw.githubusercontent.com/adrianolaselva/dataql/main/scripts/install
 **Linux / macOS:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/adrianolaselva/dataql/main/scripts/install.sh | bash -s -- --version v0.1.0
+curl -fsSL https://raw.githubusercontent.com/adrianolaselva/dataql/main/scripts/install.sh | bash -s -- --version v1.0.0
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-$env:DATAQL_VERSION="v0.1.0"; irm https://raw.githubusercontent.com/adrianolaselva/dataql/main/scripts/install.ps1 | iex
+$env:DATAQL_VERSION="v1.0.0"; irm https://raw.githubusercontent.com/adrianolaselva/dataql/main/scripts/install.ps1 | iex
 ```
 
 ### User Installation (No sudo required)


### PR DESCRIPTION
## Summary

This PR fixes critical issues in the installation script (`scripts/install.sh`) that prevented proper reinstallation when using `--force`, `--clean`, and `--upgrade` flags.

## Problem

The installation script was not reinstalling the application regardless of which flags were used:
- `--clean --force` did not reinstall
- `--force` did not reinstall  
- `--upgrade` did not reinstall
- The application always kept the first installed version

## Root Cause

The main issue was that the `compare_versions` function returns non-zero exit codes (1 or 2) to indicate comparison results:
- `return 0` = versions equal
- `return 1` = first version > second
- `return 2` = first version < second

With `set -e` at the top of the script, any command returning non-zero causes immediate script termination. When `compare_versions` returned 1 or 2, the script exited before reaching the download/install logic.

## Changes

### Bug Fixes
- **Fix version comparison exit**: Added `|| true` after `compare_versions` call to prevent `set -e` from exiting on non-zero returns
- **Simplify --force logic**: When `--force` is specified, skip version comparison entirely and always reinstall
- **Verify clean success**: Added verification after `clean_all_installations` to ensure binary was actually removed
- **Force binary replacement**: Remove existing binary before copying new one to ensure clean replacement

### Improvements
- **Add --reinstall alias**: Added `--reinstall` as an alias for `--force` for clearer intent
- **Display installation mode**: Show active flags (clean/force/upgrade/local) at the start of installation
- **Clear shell hash table**: Call `hash -r` after clean to prevent shell caching issues
- **Update documentation**: Updated version references to v1.0.0

## Files Changed

| File | Changes |
|------|---------|
| `scripts/install.sh` | Fix version comparison, improve --force/--clean logic, add --reinstall alias |
| `docs/getting-started.md` | Update version references from v0.1.0 to v1.0.0 |

## Testing

- ✅ All 11 installation E2E tests pass
- ✅ All unit tests pass (380+ tests)
- ✅ `--force` now properly reinstalls
- ✅ `--clean --force` now properly cleans and reinstalls
- ✅ `--upgrade` now properly upgrades when newer version available
- ✅ `--reinstall` alias works correctly

## Test Commands

```bash
# Build and run installation tests
make build
make e2e-test-install

# Test specific scenarios
./scripts/install.sh --help
./scripts/install.sh --force
./scripts/install.sh --clean --force
./scripts/install.sh --upgrade
./scripts/install.sh --reinstall
```

## Installation Script Usage

```bash
# First time install
curl -fsSL https://raw.githubusercontent.com/adrianolaselva/dataql/main/scripts/install.sh | bash

# Force reinstall
curl -fsSL .../install.sh | bash -s -- --force

# Clean and reinstall
curl -fsSL .../install.sh | bash -s -- --clean --force

# Upgrade to latest
curl -fsSL .../install.sh | bash -s -- --upgrade

# Install specific version
curl -fsSL .../install.sh | bash -s -- --version v1.0.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)