### PR TITLE
docs: update documentation to reflect DuckDB storage engine migration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -435,7 +435,7 @@ DataQL employs several design patterns for maintainability and extensibility:
 
 | Category | Formats |
 |----------|---------|
-| **Files** | CSV, JSON, JSONL, XML, YAML, Parquet, Excel (.xlsx, .xls), Avro, ORC, SQLite |
+| **Files** | CSV, JSON, JSONL, XML, YAML, Parquet, Excel (.xlsx, .xls), Avro, ORC, SQLite (.db) |
 | **Databases** | PostgreSQL, MySQL, DuckDB, MongoDB, DynamoDB |
 | **Cloud Storage** | Amazon S3, Google Cloud Storage, Azure Blob Storage |
 | **Message Queues** | AWS SQS, Apache Kafka (peek mode - non-consuming) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -329,11 +329,17 @@ LEFT JOIN table2 b ON a.id = b.foreign_id;
 |----------|-------------|
 | `COUNT(*)` | Count rows |
 | `COUNT(column)` | Count non-null values |
+| `COUNT(DISTINCT column)` | Count distinct values |
 | `SUM(column)` | Sum of values |
 | `AVG(column)` | Average of values |
 | `MIN(column)` | Minimum value |
 | `MAX(column)` | Maximum value |
-| `GROUP_CONCAT(column)` | Concatenate values |
+| `STRING_AGG(column, delimiter)` | Concatenate values with delimiter |
+| `ARRAY_AGG(column)` | Aggregate into array |
+| `MEDIAN(column)` | Median value |
+| `MODE(column)` | Most frequent value |
+| `STDDEV(column)` | Standard deviation |
+| `VARIANCE(column)` | Variance |
 
 ### String Functions
 
@@ -343,26 +349,92 @@ LEFT JOIN table2 b ON a.id = b.foreign_id;
 | `UPPER(str)` | Convert to uppercase |
 | `LOWER(str)` | Convert to lowercase |
 | `TRIM(str)` | Remove leading/trailing spaces |
-| `SUBSTR(str, start, len)` | Extract substring |
+| `LTRIM(str)` | Remove leading spaces |
+| `RTRIM(str)` | Remove trailing spaces |
+| `SUBSTRING(str, start, len)` | Extract substring |
 | `REPLACE(str, old, new)` | Replace occurrences |
-| `INSTR(str, substr)` | Find position of substring |
+| `POSITION(substr IN str)` | Find position of substring |
+| `CONCAT(str1, str2, ...)` | Concatenate strings |
+| `SPLIT_PART(str, delim, n)` | Split and get nth part |
+| `REGEXP_MATCHES(str, pattern)` | Regex matching |
+| `REGEXP_REPLACE(str, pattern, repl)` | Regex replace |
+| `LEFT(str, n)` | Left n characters |
+| `RIGHT(str, n)` | Right n characters |
+| `REVERSE(str)` | Reverse string |
 
 ### Date/Time Functions
 
 | Function | Description |
 |----------|-------------|
-| `DATE(value)` | Extract date |
-| `TIME(value)` | Extract time |
-| `DATETIME(value)` | Date and time |
-| `STRFTIME(format, value)` | Format date/time |
-| `JULIANDAY(value)` | Julian day number |
+| `CURRENT_DATE` | Current date |
+| `CURRENT_TIME` | Current time |
+| `CURRENT_TIMESTAMP` | Current timestamp |
+| `DATE_PART('part', value)` | Extract part (year, month, day, hour, etc.) |
+| `DATE_TRUNC('part', value)` | Truncate to specified precision |
+| `STRFTIME(value, format)` | Format date/time |
+| `DATE_DIFF('part', start, end)` | Difference between dates |
+| `DATE_ADD(date, INTERVAL n unit)` | Add interval to date |
+| `EXTRACT(part FROM value)` | Extract part from timestamp |
+
+### Window Functions
+
+| Function | Description |
+|----------|-------------|
+| `ROW_NUMBER() OVER (...)` | Row number within partition |
+| `RANK() OVER (...)` | Rank with gaps |
+| `DENSE_RANK() OVER (...)` | Rank without gaps |
+| `LAG(col, n) OVER (...)` | Access previous row value |
+| `LEAD(col, n) OVER (...)` | Access next row value |
+| `FIRST_VALUE(col) OVER (...)` | First value in window |
+| `LAST_VALUE(col) OVER (...)` | Last value in window |
+| `SUM(col) OVER (...)` | Running sum |
+| `AVG(col) OVER (...)` | Running average |
 
 ### Type Conversion
 
 ```sql
 SELECT CAST(amount AS INTEGER) FROM data;
-SELECT CAST(price AS REAL) FROM data;
-SELECT CAST(id AS TEXT) FROM data;
+SELECT CAST(price AS DOUBLE) FROM data;
+SELECT CAST(id AS VARCHAR) FROM data;
+SELECT TRY_CAST(value AS INTEGER) FROM data;  -- Returns NULL on error
+```
+
+### Common Table Expressions (CTEs)
+
+```sql
+WITH active_users AS (
+    SELECT * FROM users WHERE status = 'active'
+)
+SELECT * FROM active_users WHERE age > 30;
+```
+
+### CASE Expressions
+
+```sql
+SELECT
+    name,
+    CASE
+        WHEN amount > 1000 THEN 'high'
+        WHEN amount > 100 THEN 'medium'
+        ELSE 'low'
+    END as tier
+FROM data;
+```
+
+### Analytical Functions
+
+```sql
+-- Percentiles
+SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY amount) as median FROM data;
+
+-- String aggregation
+SELECT STRING_AGG(name, ', ') as names FROM data GROUP BY category;
+
+-- Conditional aggregation
+SELECT
+    COUNT(*) FILTER (WHERE status = 'active') as active_count,
+    COUNT(*) FILTER (WHERE status = 'inactive') as inactive_count
+FROM users;
 ```
 
 ## Environment Variables

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -333,7 +333,7 @@ dataql run -f "dynamodb://us-east-1/my-data-table" -c my_table \
 
 1. DataQL scans the DynamoDB table using the AWS SDK
 2. The schema is inferred from the first item in the table
-3. Data is loaded into an in-memory SQLite database
+3. Data is loaded into an in-memory DuckDB database
 4. You can then query the data using standard SQL syntax
 
 ### Limitations

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -407,7 +407,7 @@ dataql run \
   -q "SELECT order_id, customer_id, total FROM orders" \
   -e orders.csv -t csv
 
-# Custom table name in SQLite
+# Custom table name
 dataql run \
   -f "dynamodb://us-east-1/my-data-table" -c my_table \
   -q "SELECT * FROM my_table LIMIT 100"
@@ -477,7 +477,7 @@ dataql run \
 
 ### Limitations
 
-1. **No native DynamoDB queries**: DataQL scans the table and loads data into SQLite
+1. **No native DynamoDB queries**: DataQL scans the table and loads data into DuckDB
 2. **Memory usage**: Large tables are fully loaded into memory
 3. **Consistent schema**: Tables with varying item structures may have missing columns
 4. **Read-only**: DataQL only reads data, doesn't write to DynamoDB

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -429,11 +429,14 @@ LIMIT 10000
 ### Persist for Multiple Queries
 
 ```bash
-# Save to SQLite for repeated queries
-dataql run -f large_data.csv -s ./data.db
+# Save to DuckDB for repeated queries
+dataql run -f large_data.csv -s ./data.duckdb
 
-# Later, query the SQLite directly
-sqlite3 ./data.db "SELECT * FROM large_data WHERE condition"
+# Later, query the DuckDB file
+dataql run -f "duckdb:///./data.duckdb?table=large_data" -q "SELECT * FROM large_data WHERE condition"
+
+# Or use DuckDB CLI directly
+duckdb ./data.duckdb "SELECT * FROM large_data WHERE condition"
 ```
 
 ## Automation Scripts

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ title: DataQL - SQL for Any Data Format
 > A powerful CLI tool for querying and transforming data across multiple formats
 
 DataQL is a CLI tool developed in Go that allows you to query and manipulate data files using SQL statements.
-It loads data into an SQLite database (in-memory or file-based) enabling powerful SQL operations on your data.
+It loads data into a DuckDB database (in-memory or file-based) with automatic type inference, enabling powerful SQL operations optimized for analytical queries.
 
 ---
 
@@ -92,8 +92,8 @@ dataql run -f sales.csv -q "SELECT region, SUM(revenue) FROM sales GROUP BY regi
 - MongoDB
 
 **Key Capabilities:**
-- Execute SQL queries using SQLite syntax
-- Export results to CSV or JSONL formats
+- Execute SQL queries using DuckDB syntax (OLAP-optimized)
+- Export results to CSV, JSONL, JSON, Excel, Parquet, XML, YAML formats
 - Interactive REPL mode with command history
 - Progress bar for large file operations
 - Parallel file processing for multiple inputs


### PR DESCRIPTION
## Summary

This PR updates all documentation to reflect the migration from SQLite to DuckDB as the storage engine. The documentation now accurately describes DuckDB syntax, functions, and capabilities.

## Changes

### SQLite → DuckDB References Updated

| File | Changes |
|------|---------|
| `index.md` | Updated description to mention DuckDB, OLAP optimization, and expanded export formats |
| `docs/architecture.md` | Clarified that SQLite is supported as input format (not storage engine) |
| `docs/cli-reference.md` | Added DuckDB-specific SQL functions documentation |
| `docs/data-sources.md` | Updated DynamoDB storage description |
| `docs/databases.md` | Updated storage engine references |
| `docs/examples.md` | Updated persistence examples to use `.duckdb` extension |

### New CLI Reference Documentation

Added comprehensive DuckDB SQL function reference:

#### Window Functions
- `ROW_NUMBER() OVER (...)`
- `RANK() OVER (...)`
- `DENSE_RANK() OVER (...)`
- `LAG(col, n) OVER (...)`
- `LEAD(col, n) OVER (...)`
- `FIRST_VALUE(col) OVER (...)`
- `LAST_VALUE(col) OVER (...)`
- `SUM(col) OVER (...)`
- `AVG(col) OVER (...)`

#### Date/Time Functions
- `CURRENT_DATE`, `CURRENT_TIME`, `CURRENT_TIMESTAMP`
- `DATE_PART('part', value)`
- `DATE_TRUNC('part', value)`
- `DATE_DIFF('part', start, end)`
- `DATE_ADD(date, INTERVAL n unit)`
- `EXTRACT(part FROM value)`

#### Enhanced Aggregate Functions
- `STRING_AGG(column, delimiter)` (replaces GROUP_CONCAT)
- `ARRAY_AGG(column)`
- `MEDIAN(column)`
- `MODE(column)`
- `STDDEV(column)`
- `VARIANCE(column)`

#### Enhanced String Functions
- `SPLIT_PART(str, delim, n)`
- `REGEXP_MATCHES(str, pattern)`
- `REGEXP_REPLACE(str, pattern, repl)`
- `LEFT(str, n)`, `RIGHT(str, n)`
- `REVERSE(str)`

#### New SQL Features Documented
- **Common Table Expressions (CTEs)**: `WITH ... AS (...)`
- **CASE Expressions**: `CASE WHEN ... THEN ... ELSE ... END`
- **Analytical Functions**: `PERCENTILE_CONT`, `STRING_AGG`, conditional aggregation with `FILTER`
- **Safe Type Conversion**: `TRY_CAST` (returns NULL on error)

### Examples Updated

The persistence example now correctly shows:

```bash
# Save to DuckDB for repeated queries
dataql run -f large_data.csv -s ./data.duckdb

# Query the DuckDB file later
dataql run -f "duckdb:///./data.duckdb?table=large_data" -q "SELECT * FROM large_data"

# Or use DuckDB CLI directly
duckdb ./data.duckdb "SELECT * FROM large_data WHERE condition"
```

## Testing

- ✅ Build succeeds
- ✅ Verified DuckDB-specific functions work:
  - `STRING_AGG()` - String aggregation with delimiter
  - `ROW_NUMBER() OVER ()` - Window functions
  - `TRY_CAST()` - Safe type conversion

## Notes

- The README.md was already updated to mention DuckDB in a previous PR
- SQLite is still supported as an **input format** (you can query `.db` files)
- The skill documentation files were reviewed and don't require changes (they use generic SQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)