### PR TITLE
docs: Fix stdin table name from 'stdin' to 'stdin_data'

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ dataql run -f "sqs://my-events-queue?region=us-east-1" \
 **Read from stdin:**
 
 ```bash
-cat data.csv | dataql run -f - -q "SELECT * FROM stdin WHERE value > 100"
+cat data.csv | dataql run -f - -q "SELECT * FROM stdin_data WHERE value > 100"
 ```
 
 ### Real-World Example

--- a/cmd/skillsctl/embedded/skills/dataql-quick/SKILL.md
+++ b/cmd/skillsctl/embedded/skills/dataql-quick/SKILL.md
@@ -51,8 +51,10 @@ dataql run -f products.csv -q "SELECT name, price FROM products WHERE price > 10
 
 ### Read from stdin
 ```bash
-cat data.csv | dataql run -f - -q "SELECT * FROM stdin LIMIT 5"
+cat data.csv | dataql run -f - -q "SELECT * FROM stdin_data LIMIT 5"
 ```
+
+**Note:** When reading from stdin, the default table name is `stdin_data`.
 
 ## Supported Formats
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -74,11 +74,13 @@ dataql run -f "https://example.com/data.csv" -q "SELECT * FROM data"
 
 ```bash
 # Pipe data from other commands
-cat data.csv | dataql run -f - -q "SELECT * FROM stdin"
+cat data.csv | dataql run -f - -q "SELECT * FROM stdin_data"
 
 # Pipe JSON
-echo '[{"a":1},{"a":2}]' | dataql run -f - -q "SELECT * FROM stdin"
+echo '[{"a":1},{"a":2}]' | dataql run -f - -i json -q "SELECT * FROM stdin_data"
 ```
+
+**Note:** When reading from stdin, the default table name is `stdin_data`. Use `-c` flag to specify a custom table name.
 
 ### Cloud Storage
 
@@ -254,7 +256,7 @@ dataql run -f "https://raw.githubusercontent.com/datasets/population/main/data/p
 ### Pipe from curl
 
 ```bash
-curl -s "https://api.example.com/data.json" | dataql run -f - -q "SELECT * FROM stdin"
+curl -s "https://api.example.com/data.json" | dataql run -f - -i json -q "SELECT * FROM stdin_data"
 ```
 
 ## SQL Reference

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -63,32 +63,35 @@ dataql run \
 
 ## Standard Input (stdin)
 
-Read data from stdin using `-` as the file path:
+Read data from stdin using `-` as the file path. The default table name is `stdin_data`:
 
 ```bash
 # Pipe CSV data
-cat data.csv | dataql run -f - -q "SELECT * FROM stdin"
+cat data.csv | dataql run -f - -q "SELECT * FROM stdin_data"
 
 # Pipe JSON data
-echo '[{"name":"Alice","age":30},{"name":"Bob","age":25}]' | dataql run -f - -q "SELECT * FROM stdin"
+echo '[{"name":"Alice","age":30},{"name":"Bob","age":25}]' | dataql run -f - -i json -q "SELECT * FROM stdin_data"
 
 # Combine with curl
-curl -s "https://api.example.com/data.json" | dataql run -f - -q "SELECT * FROM stdin"
+curl -s "https://api.example.com/data.json" | dataql run -f - -i json -q "SELECT * FROM stdin_data"
 
 # Process command output
-ps aux | dataql run -f - -d " " -q "SELECT * FROM stdin LIMIT 10"
+ps aux | dataql run -f - -d " " -q "SELECT * FROM stdin_data LIMIT 10"
 ```
 
 ### stdin with Different Formats
 
-The format is auto-detected from the content:
+Use the `-i` flag to specify the input format:
 
 ```bash
 # JSON from stdin
-echo '{"users":[{"name":"Alice"},{"name":"Bob"}]}' | dataql run -f - -q "SELECT * FROM stdin"
+echo '{"users":[{"name":"Alice"},{"name":"Bob"}]}' | dataql run -f - -i json -q "SELECT * FROM stdin_data"
 
 # CSV from stdin
-echo -e "id,name\n1,Alice\n2,Bob" | dataql run -f - -q "SELECT * FROM stdin"
+echo -e "id,name\n1,Alice\n2,Bob" | dataql run -f - -i csv -q "SELECT * FROM stdin_data"
+
+# Custom table name
+echo -e "id,name\n1,Alice" | dataql run -f - -c people -q "SELECT * FROM people"
 ```
 
 ## Amazon S3

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -329,9 +329,9 @@ dataql run \
 ```bash
 # Pipe API response
 curl -s "https://api.github.com/users/octocat/repos" | \
-    dataql run -f - -q "
+    dataql run -f - -i json -q "
     SELECT name, stargazers_count, language
-    FROM stdin
+    FROM stdin_data
     WHERE language IS NOT NULL
     ORDER BY stargazers_count DESC
     LIMIT 10

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -288,14 +288,16 @@ Pipe data directly to DataQL:
 
 ```bash
 # Pipe CSV data
-cat users.csv | dataql run -f - -q "SELECT * FROM stdin WHERE age > 30"
+cat users.csv | dataql run -f - -q "SELECT * FROM stdin_data WHERE age > 30"
 
 # Pipe JSON data
-echo '[{"a":1},{"a":2}]' | dataql run -f - -q "SELECT * FROM stdin"
+echo '[{"a":1},{"a":2}]' | dataql run -f - -i json -q "SELECT * FROM stdin_data"
 
 # Combine with other tools
-curl -s "https://api.example.com/data.json" | dataql run -f - -q "SELECT * FROM stdin"
+curl -s "https://api.example.com/data.json" | dataql run -f - -i json -q "SELECT * FROM stdin_data"
 ```
+
+**Note:** When reading from stdin, the default table name is `stdin_data`. Use `-c` to specify a custom table name.
 
 ## Next Steps
 

--- a/index.md
+++ b/index.md
@@ -150,7 +150,7 @@ dataql run -f "s3://my-bucket/data.csv" -q "SELECT * FROM data"
 dataql run -f "postgres://user:pass@localhost/db?table=users" -q "SELECT * FROM users"
 
 # Read from stdin
-cat data.csv | dataql run -f - -q "SELECT * FROM stdin"
+cat data.csv | dataql run -f - -q "SELECT * FROM stdin_data"
 
 # Export results
 dataql run -f input.csv -q "SELECT * FROM input" -e output.jsonl -t jsonl


### PR DESCRIPTION
## Summary

Fixes #18

This PR corrects the documentation that incorrectly stated the table name is `stdin` when reading from stdin. The actual table name is `stdin_data`.

## Problem

The documentation in multiple files showed:
```bash
cat data.csv | dataql run -f - -q "SELECT * FROM stdin"
```

But the actual behavior creates a table named `stdin_data`, causing users to get:
```
Catalog Error: Table with name stdin does not exist!
Did you mean "stdin_data"?
```

## Root Cause

In `pkg/stdinhandler/stdinhandler.go:81`, the temp file is created as:
```go
localPath := filepath.Join(h.tempDir, "stdin_data"+ext)
```

This means the table name is derived from `stdin_data.csv`, resulting in table name `stdin_data`.

## Solution

Updated all documentation to use the correct table name `stdin_data`:

| File | Changes |
|------|---------|
| `README.md` | Fixed stdin example |
| `index.md` | Fixed stdin example |
| `docs/cli-reference.md` | Fixed examples, added note about table name |
| `docs/data-sources.md` | Fixed all stdin examples, added note |
| `docs/examples.md` | Fixed curl piping example |
| `docs/getting-started.md` | Fixed all stdin examples, added note |
| `cmd/skillsctl/embedded/skills/dataql-quick/SKILL.md` | Fixed example, added note |

## Additional Improvements

- Added notes explaining the default table name behavior
- Added examples showing the `-c` flag for custom table names
- Added `-i` flag examples for explicit format specification

## Test Plan

- [x] All existing E2E tests pass (especially `stdin_test.go`)
- [x] Documentation examples verified against actual behavior
- [x] Build succeeds

## Verification

After this fix, users can correctly query stdin data:
```bash
# Works correctly
cat data.csv | dataql run -f - -q "SELECT * FROM stdin_data"

# Or with custom table name
cat data.csv | dataql run -f - -c mydata -q "SELECT * FROM mydata"
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)