### PR TITLE
feat: Allow --storage flag without --file to query existing DuckDB

### DIFF
--- a/tests/e2e/storage_only_test.go
+++ b/tests/e2e/storage_only_test.go
@@ -1,0 +1,169 @@
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStorageOnly_QueryExistingDatabase(t *testing.T) {
+	// Create test data
+	csvData := `id,name,age
+1,Alice,30
+2,Bob,25
+3,Charlie,35`
+
+	csvFile := tempFileWithContent(t, "test_users.csv", csvData)
+	dbFile := tempFile(t, "test.duckdb")
+
+	// First, create the database with data
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", csvFile,
+		"-s", dbFile,
+		"-q", "SELECT COUNT(*) as total FROM test_users")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "3")
+
+	// Now query the existing database without --file flag
+	stdout, stderr, err = runDataQL(t, "run",
+		"-s", dbFile,
+		"-q", "SELECT * FROM test_users ORDER BY id")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Alice")
+	assertContains(t, stdout, "Bob")
+	assertContains(t, stdout, "Charlie")
+}
+
+func TestStorageOnly_QueryWithAggregation(t *testing.T) {
+	// Create test data
+	csvData := `product,price,quantity
+Laptop,999.99,5
+Mouse,29.99,20
+Keyboard,89.99,15`
+
+	csvFile := tempFileWithContent(t, "products.csv", csvData)
+	dbFile := tempFile(t, "products.duckdb")
+
+	// Create the database
+	_, stderr, err := runDataQL(t, "run",
+		"-f", csvFile,
+		"-s", dbFile,
+		"-q", "SELECT 1")
+
+	assertNoError(t, err, stderr)
+
+	// Query with aggregation
+	stdout, stderr, err := runDataQL(t, "run",
+		"-s", dbFile,
+		"-q", "SELECT SUM(price * quantity) as total_value FROM products")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "total_value")
+}
+
+func TestStorageOnly_MultipleTables(t *testing.T) {
+	// Create test data files
+	usersCSV := `id,name
+1,Alice
+2,Bob`
+	ordersCSV := `id,user_id,total
+1,1,100
+2,1,200
+3,2,150`
+
+	usersFile := tempFileWithContent(t, "users.csv", usersCSV)
+	ordersFile := tempFileWithContent(t, "orders.csv", ordersCSV)
+	dbFile := tempFile(t, "multi.duckdb")
+
+	// Load first table
+	_, stderr, err := runDataQL(t, "run",
+		"-f", usersFile,
+		"-s", dbFile,
+		"-q", "SELECT 1")
+
+	assertNoError(t, err, stderr)
+
+	// Load second table
+	_, stderr, err = runDataQL(t, "run",
+		"-f", ordersFile,
+		"-s", dbFile,
+		"-q", "SELECT 1")
+
+	assertNoError(t, err, stderr)
+
+	// Query both tables with JOIN
+	stdout, stderr, err := runDataQL(t, "run",
+		"-s", dbFile,
+		"-q", "SELECT u.name, SUM(o.total) as total FROM users u JOIN orders o ON u.id = o.user_id GROUP BY u.id, u.name")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Alice")
+	assertContains(t, stdout, "Bob")
+}
+
+func TestStorageOnly_ErrorNoFileOrStorage(t *testing.T) {
+	_, stderr, err := runDataQL(t, "run",
+		"-q", "SELECT 1")
+
+	assertError(t, err)
+	assertContains(t, stderr, "either --file or --storage")
+}
+
+func TestStorageOnly_ErrorNonExistentStorage(t *testing.T) {
+	nonExistentPath := filepath.Join(os.TempDir(), "nonexistent_db_"+randomString(8)+".duckdb")
+
+	_, stderr, err := runDataQL(t, "run",
+		"-s", nonExistentPath,
+		"-q", "SELECT 1")
+
+	assertError(t, err)
+	assertContains(t, stderr, "storage file does not exist")
+}
+
+func TestStorageOnly_ListTables(t *testing.T) {
+	// Create test data
+	csvData := `col1,col2
+a,b`
+
+	csvFile := tempFileWithContent(t, "mytable.csv", csvData)
+	dbFile := tempFile(t, "list.duckdb")
+
+	// Create database
+	_, stderr, err := runDataQL(t, "run",
+		"-f", csvFile,
+		"-s", dbFile,
+		"-q", "SELECT 1")
+
+	assertNoError(t, err, stderr)
+
+	// Query .tables command (shows tables when running in storage-only mode)
+	stdout, stderr, err := runDataQL(t, "run",
+		"-s", dbFile,
+		"-q", ".tables")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "mytable")
+}
+
+// Helper function to create temp file with content
+func tempFileWithContent(t *testing.T, name, content string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, name)
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	return filePath
+}
+
+// Helper function to generate random string
+func randomString(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[i%len(letters)]
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Summary

Fixes #19

This PR allows users to query an existing DuckDB database using only the `--storage` flag, without needing to specify an input file via `--file`.

## Problem

Previously, the `--file` flag was mandatory, preventing users from querying previously saved data:

```bash
# This would fail with: Error: required flag(s) "file" not set
dataql run -s mydb.duckdb -q "SELECT COUNT(*) FROM users"
```

## Solution

Implemented a "storage-only" mode that:
1. Detects when `--storage` is provided without `--file`
2. Verifies the DuckDB file exists
3. Opens the existing database and allows queries/REPL mode
4. Skips the data import phase

### Changes

| File | Description |
|------|-------------|
| `cmd/dataqlctl/dataqlctl.go` | Removed mandatory `--file` flag, added conditional routing |
| `internal/dataql/dataql.go` | Added `NewStorageOnly()` and `RunStorageOnly()` methods |
| `tests/e2e/storage_only_test.go` | Comprehensive E2E test suite |

## Usage

```bash
# First, save data to DuckDB
dataql run -f users.csv -s mydb.duckdb -q "SELECT * FROM users"

# Later, query the existing DuckDB
dataql run -s mydb.duckdb -q "SELECT COUNT(*) FROM users"

# Or start REPL mode with existing data
dataql run -s mydb.duckdb
```

## Error Handling

| Scenario | Error Message |
|----------|---------------|
| Neither `--file` nor `--storage` | `either --file or --storage with an existing DuckDB file is required` |
| `--storage` file doesn't exist | `storage file does not exist: /path/to/file (use --file to create a new database)` |

## Test Plan

- [x] E2E test: Query existing database without `--file`
- [x] E2E test: Aggregation queries in storage-only mode
- [x] E2E test: Multiple tables in storage-only mode
- [x] E2E test: Error when neither flag is provided
- [x] E2E test: Error when storage file doesn't exist
- [x] E2E test: List tables in storage-only mode
- [x] All existing tests pass

## Verification

```bash
# Create database
dataql run -f users.csv -s test.duckdb -q "SELECT * FROM users"

# Query without --file (now works!)
dataql run -s test.duckdb -q "SELECT COUNT(*) FROM users"
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)