### PR TITLE
feat(describe): add describe command for exploratory statistics (#26)

### DIFF
--- a/cmd/describectl/describectl.go
+++ b/cmd/describectl/describectl.go
@@ -1,0 +1,139 @@
+package describectl
+
+import (
+	"fmt"
+
+	"github.com/adrianolaselva/dataql/internal/dataql"
+	"github.com/spf13/cobra"
+)
+
+const (
+	fileParam               = "file"
+	fileShortParam          = "f"
+	fileDelimiterParam      = "delimiter"
+	fileShortDelimiterParam = "d"
+	storageParam            = "storage"
+	storageShortParam       = "s"
+	linesParam              = "lines"
+	linesShortParam         = "l"
+	tableNameParam          = "collection"
+	tableNameShortParam     = "c"
+	verboseParam            = "verbose"
+	verboseShortParam       = "v"
+	inputFormatParam        = "input-format"
+	inputFormatShortParam   = "i"
+	quietParam              = "quiet"
+	quietShortParam         = "Q"
+)
+
+// DescribeCtl is the interface for the describe controller
+type DescribeCtl interface {
+	Command() (*cobra.Command, error)
+	runE(cmd *cobra.Command, args []string) error
+}
+
+type describeCtl struct {
+	params dataql.Params
+}
+
+// New creates a new DescribeCtl instance
+func New() DescribeCtl {
+	return &describeCtl{}
+}
+
+// Command returns the cobra command for the describe subcommand
+func (c *describeCtl) Command() (*cobra.Command, error) {
+	command := &cobra.Command{
+		Use:   "describe",
+		Short: "Show exploratory statistics for data files",
+		Long: `Show comprehensive statistics for data files including:
+  - Row count
+  - Data types
+  - Min/Max values (for numeric and date columns)
+  - Mean, median, standard deviation (for numeric columns)
+  - Null count per column
+  - Unique values count`,
+		Example: `  dataql describe -f data.csv
+  dataql describe -f sales.json
+  dataql describe -f users.parquet -c mydata`,
+		RunE: c.runE,
+	}
+
+	command.
+		PersistentFlags().
+		StringArrayVarP(&c.params.FileInputs, fileParam, fileShortParam, []string{}, "origin file (csv, json, etc.)")
+
+	command.
+		PersistentFlags().
+		StringVarP(&c.params.Delimiter, fileDelimiterParam, fileShortDelimiterParam, ",", "csv delimiter")
+
+	command.
+		PersistentFlags().
+		StringVarP(&c.params.DataSourceName, storageParam, storageShortParam, "", "DuckDB file path for persistence (default: in-memory)")
+
+	command.
+		PersistentFlags().
+		IntVarP(&c.params.Lines, linesParam, linesShortParam, 0, "number of lines to be read")
+
+	command.
+		PersistentFlags().
+		StringVarP(&c.params.Collection, tableNameParam, tableNameShortParam, "", "custom table name (collection) for the imported data")
+
+	command.
+		PersistentFlags().
+		BoolVarP(&c.params.Verbose, verboseParam, verboseShortParam, false, "enable verbose output with detailed logging")
+
+	command.
+		PersistentFlags().
+		StringVarP(&c.params.InputFormat, inputFormatParam, inputFormatShortParam, "csv", "input format when using stdin (csv, json, jsonl, xml, yaml)")
+
+	command.
+		PersistentFlags().
+		BoolVarP(&c.params.Quiet, quietParam, quietShortParam, false, "suppress progress bar output (useful for pipelines)")
+
+	return command, nil
+}
+
+func (c *describeCtl) runE(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+
+	// Check if we have file inputs or storage-only mode
+	hasFileInputs := len(c.params.FileInputs) > 0
+	hasStorage := c.params.DataSourceName != ""
+
+	// If no file inputs and no storage, we need at least one source
+	if !hasFileInputs && !hasStorage {
+		return fmt.Errorf("either --file or --storage with an existing DuckDB file is required")
+	}
+
+	// If no file inputs but storage is provided, describe existing DuckDB
+	if !hasFileInputs && hasStorage {
+		dql, err := dataql.NewStorageOnly(c.params)
+		if err != nil {
+			return fmt.Errorf("failed to initialize dataql: %w", err)
+		}
+		defer func(dql dataql.DataQL) {
+			_ = dql.Close()
+		}(dql)
+
+		if err := dql.DescribeAll(); err != nil {
+			return fmt.Errorf("failed to describe data: %w", err)
+		}
+		return nil
+	}
+
+	// Normal mode with file inputs
+	dql, err := dataql.New(c.params)
+	if err != nil {
+		return fmt.Errorf("failed to initialize dataql: %w", err)
+	}
+	defer func(dql dataql.DataQL) {
+		_ = dql.Close()
+	}(dql)
+
+	if err := dql.RunAndDescribe(); err != nil {
+		return fmt.Errorf("failed to describe data: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/describectl/describectl_test.go
+++ b/cmd/describectl/describectl_test.go
@@ -1,0 +1,93 @@
+package describectl
+
+import (
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	ctl := New()
+	if ctl == nil {
+		t.Error("New() should not return nil")
+	}
+}
+
+func TestCommand(t *testing.T) {
+	ctl := New()
+	cmd, err := ctl.Command()
+	if err != nil {
+		t.Errorf("Command() returned error: %v", err)
+	}
+	if cmd == nil {
+		t.Error("Command() should not return nil")
+	}
+
+	// Check command properties
+	if cmd.Use != "describe" {
+		t.Errorf("Expected Use to be 'describe', got '%s'", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Error("Short description should not be empty")
+	}
+
+	if cmd.Long == "" {
+		t.Error("Long description should not be empty")
+	}
+
+	if cmd.Example == "" {
+		t.Error("Example should not be empty")
+	}
+}
+
+func TestCommand_Flags(t *testing.T) {
+	ctl := New()
+	cmd, err := ctl.Command()
+	if err != nil {
+		t.Fatalf("Command() returned error: %v", err)
+	}
+
+	// Test required flags exist
+	flags := []struct {
+		name      string
+		shorthand string
+	}{
+		{"file", "f"},
+		{"delimiter", "d"},
+		{"storage", "s"},
+		{"lines", "l"},
+		{"collection", "c"},
+		{"verbose", "v"},
+		{"input-format", "i"},
+		{"quiet", "Q"},
+	}
+
+	for _, flag := range flags {
+		f := cmd.PersistentFlags().Lookup(flag.name)
+		if f == nil {
+			t.Errorf("Flag '%s' should exist", flag.name)
+			continue
+		}
+		if f.Shorthand != flag.shorthand {
+			t.Errorf("Flag '%s' shorthand should be '%s', got '%s'", flag.name, flag.shorthand, f.Shorthand)
+		}
+	}
+}
+
+func TestCommand_Defaults(t *testing.T) {
+	ctl := New()
+	cmd, err := ctl.Command()
+	if err != nil {
+		t.Fatalf("Command() returned error: %v", err)
+	}
+
+	// Check default values
+	delimiterFlag := cmd.PersistentFlags().Lookup("delimiter")
+	if delimiterFlag.DefValue != "," {
+		t.Errorf("Default delimiter should be ',', got '%s'", delimiterFlag.DefValue)
+	}
+
+	inputFormatFlag := cmd.PersistentFlags().Lookup("input-format")
+	if inputFormatFlag.DefValue != "csv" {
+		t.Errorf("Default input-format should be 'csv', got '%s'", inputFormatFlag.DefValue)
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/adrianolaselva/dataql/cmd/dataqlctl"
+	"github.com/adrianolaselva/dataql/cmd/describectl"
 	"github.com/adrianolaselva/dataql/cmd/mcpctl"
 	"github.com/adrianolaselva/dataql/cmd/skillsctl"
 	"github.com/adrianolaselva/dataql/internal/dataql"
@@ -61,6 +62,13 @@ func (c *cliBase) Execute() error {
 	}
 
 	c.rootCmd.AddCommand(dataQlCtl)
+
+	// Add describe command for exploratory statistics
+	describeCmd, err := describectl.New().Command()
+	if err != nil {
+		return fmt.Errorf("failed to initialize describe command: %w", err)
+	}
+	c.rootCmd.AddCommand(describeCmd)
 
 	// Add skills command for Claude Code integration
 	c.rootCmd.AddCommand(skillsctl.New().Command())

--- a/tests/e2e/describe_test.go
+++ b/tests/e2e/describe_test.go
@@ -1,0 +1,172 @@
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDescribe_CSV(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "describe",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Table: users")
+	assertContains(t, stdout, "Total rows: 3")
+	assertContains(t, stdout, "column_name")
+	assertContains(t, stdout, "column_type")
+	assertContains(t, stdout, "id")
+	assertContains(t, stdout, "name")
+	assertContains(t, stdout, "BIGINT")
+	assertContains(t, stdout, "VARCHAR")
+}
+
+func TestDescribe_JSON(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "describe",
+		"-f", "tests/fixtures/json/people.json",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Table: people")
+	assertContains(t, stdout, "Total rows: 3")
+	assertContains(t, stdout, "age")
+	assertContains(t, stdout, "BIGINT")
+}
+
+func TestDescribe_JSONL(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "describe",
+		"-f", "tests/fixtures/jsonl/simple.jsonl",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Table: simple")
+	assertContains(t, stdout, "VARCHAR")
+}
+
+func TestDescribe_WithCustomCollection(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "describe",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-c", "my_custom_table",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Table: my_custom_table")
+	assertContains(t, stdout, "Total rows: 3")
+}
+
+func TestDescribe_WithLineLimit(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "describe",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-l", "2",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Table: users")
+	assertContains(t, stdout, "Total rows: 2")
+}
+
+func TestDescribe_MultipleFiles(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "describe",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-f", "tests/fixtures/csv/departments.csv",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Table: users")
+	assertContains(t, stdout, "Table: departments")
+}
+
+func TestDescribe_NumericStatistics(t *testing.T) {
+	// Create a CSV file with numeric data for statistics testing
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "numbers.csv")
+
+	content := "id,value,score\n1,100,85.5\n2,200,92.3\n3,300,78.9\n4,400,88.1\n5,500,95.0\n"
+	if err := os.WriteFile(csvPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write CSV file: %v", err)
+	}
+
+	stdout, stderr, err := runDataQL(t, "describe",
+		"-f", csvPath,
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Table: numbers")
+	assertContains(t, stdout, "Total rows: 5")
+	// Check for min/max values
+	assertContains(t, stdout, "1")   // min id
+	assertContains(t, stdout, "5")   // max id
+	assertContains(t, stdout, "100") // min value
+	assertContains(t, stdout, "500") // max value
+}
+
+func TestDescribe_WithNulls(t *testing.T) {
+	// Create a CSV file with null values
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "nulls.csv")
+
+	content := "id,name,value\n1,Alice,100\n2,,200\n3,Charlie,\n4,Diana,400\n"
+	if err := os.WriteFile(csvPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write CSV file: %v", err)
+	}
+
+	stdout, stderr, err := runDataQL(t, "describe",
+		"-f", csvPath,
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Table: nulls")
+	assertContains(t, stdout, "Total rows: 4")
+}
+
+func TestDescribe_CompressedFile(t *testing.T) {
+	// Create a temp gzip file
+	tmpDir := t.TempDir()
+	gzPath := filepath.Join(tmpDir, "data.csv.gz")
+
+	content := "id,name,value\n1,Alice,100\n2,Bob,200\n3,Charlie,300\n"
+	createGzipFile(t, gzPath, content)
+
+	stdout, stderr, err := runDataQL(t, "describe",
+		"-f", gzPath,
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Table: data")
+	assertContains(t, stdout, "Total rows: 3")
+}
+
+func TestDescribe_NoFileError(t *testing.T) {
+	_, _, err := runDataQL(t, "describe")
+
+	assertError(t, err)
+}
+
+func TestDescribe_NonExistentFile(t *testing.T) {
+	_, _, err := runDataQL(t, "describe",
+		"-f", "/nonexistent/file.csv")
+
+	assertError(t, err)
+}
+
+func TestDescribe_ExistingStorage(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.duckdb")
+
+	// First, create a database with some data
+	_, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-s", dbPath,
+		"-q", "SELECT 1",
+		"-Q")
+	assertNoError(t, err, stderr)
+
+	// Now describe using the existing storage
+	stdout, stderr, err := runDataQL(t, "describe",
+		"-s", dbPath,
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Table: users")
+}


### PR DESCRIPTION
## Summary

- Adds new `dataql describe` CLI command for showing comprehensive statistics
- Adds `.describe` and `\ds` REPL commands for interactive use
- Uses DuckDB's SUMMARIZE feature for efficient statistics calculation
- Includes fallback to manual queries when needed

## Features

The describe command shows:
- **Row count** - Total number of records
- **Data types** - Type of each column
- **Min/Max values** - For numeric and date columns
- **Mean, median, standard deviation** - For numeric columns
- **Null count** - Number of null/missing values per column
- **Unique values** - Count for each column

## Usage

### CLI Command
```bash
dataql describe -f data.csv
dataql describe -f sales.json -c mydata
```

### REPL Commands
```
.describe [table]  - Show statistics for all or specific table
\ds [table]        - Alias for .describe
```

## Example Output
```
=== Table: users ===

Total rows: 3

column_name    column_type  min    max      approx_unique  avg   std   q25  q50  q75  count  null_percentage  
id             BIGINT       1      3        3              2.0   1.0   1    2    3    3      0%               
name           VARCHAR      Alice  Charlie  3              -     -     -    -    -    3      0%               
department_id  BIGINT       10     20       2              13.3  5.8   10   10   18   3      0%
```

## Test plan
- [x] Unit tests for describectl command
- [x] E2E tests for various file formats (CSV, JSON, JSONL)
- [x] E2E tests for custom collection names
- [x] E2E tests for compressed files
- [x] E2E tests for existing DuckDB storage
- [x] All existing tests pass

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)