### PR TITLE
feat(params): add support for parameterized queries (#27)

### DIFF
--- a/cmd/dataqlctl/dataqlctl.go
+++ b/cmd/dataqlctl/dataqlctl.go
@@ -35,6 +35,8 @@ const (
 	truncateShortParam      = "T"
 	verticalParam           = "vertical"
 	verticalShortParam      = "G"
+	paramParam              = "param"
+	paramShortParam         = "p"
 )
 
 // DataQlCtl is the interface for the dataql controller
@@ -117,6 +119,10 @@ func (c *dataQlCtl) Command() (*cobra.Command, error) {
 	command.
 		PersistentFlags().
 		BoolVarP(&c.params.Vertical, verticalParam, verticalShortParam, false, "display results in vertical format (like MySQL \\G)")
+
+	command.
+		PersistentFlags().
+		StringArrayVarP(&c.params.QueryParams, paramParam, paramShortParam, []string{}, "query parameter in format name=value (can be repeated)")
 
 	// Note: file flag is no longer required if storage flag points to existing DuckDB file
 	// Validation is done in runE to allow querying existing DuckDB files

--- a/internal/dataql/dataql.go
+++ b/internal/dataql/dataql.go
@@ -73,10 +73,11 @@ type dataQL struct {
 	stdinHandler       *stdinhandler.StdinHandler
 	compressionHandler *compressionhandler.CompressionHandler
 	pageSize           int
-	paging             bool // Enable paging in REPL mode
-	showTiming         bool // Show query execution time
-	truncate           int  // Truncate column values longer than N characters
-	vertical           bool // Display results in vertical format
+	paging             bool              // Enable paging in REPL mode
+	showTiming         bool              // Show query execution time
+	truncate           int               // Truncate column values longer than N characters
+	vertical           bool              // Display results in vertical format
+	queryParams        map[string]string // Parsed query parameters
 }
 
 // verboseLog prints a message if verbose mode is enabled
@@ -265,6 +266,23 @@ func New(params Params) (DataQL, error) {
 		return nil, fmt.Errorf("failed to create file handler: %w", err)
 	}
 
+	// Parse query parameters if provided
+	var queryParams map[string]string
+	if len(params.QueryParams) > 0 {
+		var err error
+		queryParams, err = ParseQueryParams(params.QueryParams)
+		if err != nil {
+			_ = stdinH.Cleanup()
+			_ = urlH.Cleanup()
+			_ = s3H.Cleanup()
+			_ = gcsH.Cleanup()
+			_ = azureH.Cleanup()
+			_ = compressionH.Cleanup()
+			return nil, fmt.Errorf("failed to parse query parameters: %w", err)
+		}
+		verboseLog(params.Verbose, "Parsed query parameters: %v", queryParams)
+	}
+
 	verboseLog(params.Verbose, "DataQL initialization complete")
 	return &dataQL{
 		params:             params,
@@ -280,6 +298,7 @@ func New(params Params) (DataQL, error) {
 		pageSize:           defaultPageSize,
 		truncate:           params.Truncate,
 		vertical:           params.Vertical,
+		queryParams:        queryParams,
 	}, nil
 }
 
@@ -320,14 +339,26 @@ func NewStorageOnly(params Params) (DataQL, error) {
 			BarEnd:        "]",
 		}))
 
+	// Parse query parameters if provided
+	var queryParams map[string]string
+	if len(params.QueryParams) > 0 {
+		var err error
+		queryParams, err = ParseQueryParams(params.QueryParams)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse query parameters: %w", err)
+		}
+		verboseLog(params.Verbose, "Parsed query parameters: %v", queryParams)
+	}
+
 	verboseLog(params.Verbose, "DataQL storage-only initialization complete")
 	return &dataQL{
-		params:   params,
-		bar:      bar,
-		storage:  duckDBStorage,
-		pageSize: defaultPageSize,
-		truncate: params.Truncate,
-		vertical: params.Vertical,
+		params:      params,
+		bar:         bar,
+		storage:     duckDBStorage,
+		pageSize:    defaultPageSize,
+		truncate:    params.Truncate,
+		vertical:    params.Vertical,
+		queryParams: queryParams,
 	}, nil
 }
 
@@ -626,7 +657,10 @@ func (d *dataQL) executeQueryAndExport(line string) error {
 		_ = bar.Finish()
 	}(d.bar)
 
-	rows, err := d.storage.Query(line)
+	// Apply query parameters if provided
+	query := ApplyQueryParams(line, d.queryParams)
+
+	rows, err := d.storage.Query(query)
 	if err != nil {
 		// Enhance error with user-friendly hints
 		enhancedErr := queryerror.EnhanceError(err)
@@ -876,7 +910,10 @@ func (d *dataQL) executeQuery(line string) error {
 
 	startTime := time.Now()
 
-	rows, err := d.storage.Query(line)
+	// Apply query parameters if provided
+	query := ApplyQueryParams(line, d.queryParams)
+
+	rows, err := d.storage.Query(query)
 	if err != nil {
 		// Enhance error with user-friendly hints
 		enhancedErr := queryerror.EnhanceError(err)

--- a/internal/dataql/type.go
+++ b/internal/dataql/type.go
@@ -10,11 +10,12 @@ type Params struct {
 	Lines          int
 	Collection     string
 	Verbose        bool
-	Quiet          bool   // Suppress progress bar output
-	NoSchema       bool   // Suppress table schema display before query results
-	InputFormat    string // Input format for stdin (csv, json, jsonl, xml, yaml)
-	Truncate       int    // Truncate column values longer than N characters (0 = no truncation)
-	Vertical       bool   // Display results in vertical format (like MySQL \G)
+	Quiet          bool     // Suppress progress bar output
+	NoSchema       bool     // Suppress table schema display before query results
+	InputFormat    string   // Input format for stdin (csv, json, jsonl, xml, yaml)
+	Truncate       int      // Truncate column values longer than N characters (0 = no truncation)
+	Vertical       bool     // Display results in vertical format (like MySQL \G)
+	QueryParams    []string // Query parameters in format "name=value"
 }
 
 // FileInput represents a file path with an optional table alias
@@ -91,4 +92,191 @@ func GetAliasMap(inputs []FileInput) map[string]string {
 		}
 	}
 	return aliases
+}
+
+// ParseQueryParams parses query parameters from "name=value" format
+// Returns a map of parameter names to values
+func ParseQueryParams(params []string) (map[string]string, error) {
+	result := make(map[string]string)
+	for _, param := range params {
+		idx := indexByte(param, '=')
+		if idx == -1 {
+			return nil, &ParamError{Param: param, Message: "invalid format, expected name=value"}
+		}
+		name := param[:idx]
+		value := param[idx+1:]
+		if name == "" {
+			return nil, &ParamError{Param: param, Message: "parameter name cannot be empty"}
+		}
+		result[name] = value
+	}
+	return result, nil
+}
+
+// indexByte returns the index of the first occurrence of c in s, or -1 if not present
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// ApplyQueryParams replaces :param placeholders in query with actual values
+// Supports both :param and $param syntax
+func ApplyQueryParams(query string, params map[string]string) string {
+	if len(params) == 0 {
+		return query
+	}
+
+	result := query
+	for name, value := range params {
+		// Replace :param syntax
+		result = replaceParam(result, ":"+name, value)
+		// Replace $param syntax
+		result = replaceParam(result, "$"+name, value)
+	}
+	return result
+}
+
+// replaceParam replaces all occurrences of param placeholder with the quoted value
+// It handles word boundaries to avoid replacing partial matches
+func replaceParam(query, placeholder, value string) string {
+	result := ""
+	i := 0
+	for i < len(query) {
+		idx := indexString(query[i:], placeholder)
+		if idx == -1 {
+			result += query[i:]
+			break
+		}
+		pos := i + idx
+		endPos := pos + len(placeholder)
+
+		// Check if this is a word boundary (not part of a larger identifier)
+		isWordBoundary := true
+		if endPos < len(query) {
+			c := query[endPos]
+			if isAlphaNumeric(c) || c == '_' {
+				isWordBoundary = false
+			}
+		}
+
+		if isWordBoundary {
+			result += query[i:pos]
+			// Quote the value appropriately
+			result += quoteValue(value)
+			i = endPos
+		} else {
+			result += query[i : pos+1]
+			i = pos + 1
+		}
+	}
+	return result
+}
+
+// indexString returns the index of the first occurrence of substr in s, or -1 if not present
+func indexString(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+// isAlphaNumeric checks if a byte is alphanumeric
+func isAlphaNumeric(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// quoteValue quotes a parameter value for SQL
+// Numbers are left unquoted, strings are quoted with single quotes
+func quoteValue(value string) string {
+	// Check if it's a number
+	if isNumber(value) {
+		return value
+	}
+	// Check for common literals
+	lowerVal := toLower(value)
+	if lowerVal == "null" || lowerVal == "true" || lowerVal == "false" {
+		return value
+	}
+	// Quote as string, escaping single quotes
+	escaped := ""
+	for i := 0; i < len(value); i++ {
+		if value[i] == '\'' {
+			escaped += "''"
+		} else {
+			escaped += string(value[i])
+		}
+	}
+	return "'" + escaped + "'"
+}
+
+// isNumber checks if a string represents a number
+func isNumber(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	start := 0
+	if s[0] == '-' || s[0] == '+' {
+		start = 1
+	}
+	if start >= len(s) {
+		return false
+	}
+	hasDigit := false
+	hasDot := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if c >= '0' && c <= '9' {
+			hasDigit = true
+		} else if c == '.' && !hasDot {
+			hasDot = true
+		} else if (c == 'e' || c == 'E') && hasDigit && i+1 < len(s) {
+			// Scientific notation
+			i++
+			if i < len(s) && (s[i] == '+' || s[i] == '-') {
+				i++
+			}
+			if i >= len(s) || s[i] < '0' || s[i] > '9' {
+				return false
+			}
+			for i++; i < len(s); i++ {
+				if s[i] < '0' || s[i] > '9' {
+					return false
+				}
+			}
+			return true
+		} else {
+			return false
+		}
+	}
+	return hasDigit
+}
+
+// toLower converts a string to lowercase
+func toLower(s string) string {
+	result := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			result[i] = c + 32
+		} else {
+			result[i] = c
+		}
+	}
+	return string(result)
+}
+
+// ParamError represents an error parsing a query parameter
+type ParamError struct {
+	Param   string
+	Message string
+}
+
+func (e *ParamError) Error() string {
+	return "invalid parameter '" + e.Param + "': " + e.Message
 }

--- a/internal/dataql/type_params_test.go
+++ b/internal/dataql/type_params_test.go
@@ -1,0 +1,235 @@
+package dataql
+
+import (
+	"testing"
+)
+
+func TestParseQueryParams_Basic(t *testing.T) {
+	params := []string{"name=Alice", "age=25"}
+	result, err := ParseQueryParams(params)
+	if err != nil {
+		t.Fatalf("ParseQueryParams failed: %v", err)
+	}
+
+	if result["name"] != "Alice" {
+		t.Errorf("Expected name=Alice, got name=%s", result["name"])
+	}
+	if result["age"] != "25" {
+		t.Errorf("Expected age=25, got age=%s", result["age"])
+	}
+}
+
+func TestParseQueryParams_EmptyValue(t *testing.T) {
+	params := []string{"empty="}
+	result, err := ParseQueryParams(params)
+	if err != nil {
+		t.Fatalf("ParseQueryParams failed: %v", err)
+	}
+
+	if result["empty"] != "" {
+		t.Errorf("Expected empty='', got empty=%s", result["empty"])
+	}
+}
+
+func TestParseQueryParams_ValueWithEquals(t *testing.T) {
+	params := []string{"expr=a=b"}
+	result, err := ParseQueryParams(params)
+	if err != nil {
+		t.Fatalf("ParseQueryParams failed: %v", err)
+	}
+
+	if result["expr"] != "a=b" {
+		t.Errorf("Expected expr='a=b', got expr=%s", result["expr"])
+	}
+}
+
+func TestParseQueryParams_InvalidFormat(t *testing.T) {
+	params := []string{"invalid"}
+	_, err := ParseQueryParams(params)
+	if err == nil {
+		t.Error("Expected error for invalid format")
+	}
+}
+
+func TestParseQueryParams_EmptyName(t *testing.T) {
+	params := []string{"=value"}
+	_, err := ParseQueryParams(params)
+	if err == nil {
+		t.Error("Expected error for empty name")
+	}
+}
+
+func TestApplyQueryParams_ColonSyntax(t *testing.T) {
+	params := map[string]string{"name": "Alice"}
+	query := "SELECT * FROM users WHERE name = :name"
+	result := ApplyQueryParams(query, params)
+	expected := "SELECT * FROM users WHERE name = 'Alice'"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestApplyQueryParams_DollarSyntax(t *testing.T) {
+	params := map[string]string{"name": "Bob"}
+	query := "SELECT * FROM users WHERE name = $name"
+	result := ApplyQueryParams(query, params)
+	expected := "SELECT * FROM users WHERE name = 'Bob'"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestApplyQueryParams_MultipleParams(t *testing.T) {
+	params := map[string]string{"min": "10", "max": "100"}
+	query := "SELECT * FROM data WHERE value > :min AND value < :max"
+	result := ApplyQueryParams(query, params)
+	expected := "SELECT * FROM data WHERE value > 10 AND value < 100"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestApplyQueryParams_NumericValue(t *testing.T) {
+	params := map[string]string{"id": "42", "price": "19.99"}
+	query := "SELECT * FROM items WHERE id = :id AND price = :price"
+	result := ApplyQueryParams(query, params)
+	expected := "SELECT * FROM items WHERE id = 42 AND price = 19.99"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestApplyQueryParams_BooleanValue(t *testing.T) {
+	params := map[string]string{"active": "true", "deleted": "false"}
+	query := "SELECT * FROM users WHERE active = :active AND deleted = :deleted"
+	result := ApplyQueryParams(query, params)
+	expected := "SELECT * FROM users WHERE active = true AND deleted = false"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestApplyQueryParams_NullValue(t *testing.T) {
+	params := map[string]string{"value": "null"}
+	query := "SELECT * FROM data WHERE value = :value"
+	result := ApplyQueryParams(query, params)
+	expected := "SELECT * FROM data WHERE value = null"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestApplyQueryParams_StringWithQuotes(t *testing.T) {
+	params := map[string]string{"name": "O'Brien"}
+	query := "SELECT * FROM users WHERE name = :name"
+	result := ApplyQueryParams(query, params)
+	expected := "SELECT * FROM users WHERE name = 'O''Brien'"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestApplyQueryParams_NoParams(t *testing.T) {
+	query := "SELECT * FROM users"
+	result := ApplyQueryParams(query, nil)
+	if result != query {
+		t.Errorf("Expected unchanged query %q, got %q", query, result)
+	}
+}
+
+func TestApplyQueryParams_EmptyParams(t *testing.T) {
+	params := map[string]string{}
+	query := "SELECT * FROM users"
+	result := ApplyQueryParams(query, params)
+	if result != query {
+		t.Errorf("Expected unchanged query %q, got %q", query, result)
+	}
+}
+
+func TestApplyQueryParams_PartialMatch(t *testing.T) {
+	// Should not replace :username when only :user is defined
+	params := map[string]string{"user": "test"}
+	query := "SELECT * FROM users WHERE username = :username AND user = :user"
+	result := ApplyQueryParams(query, params)
+	expected := "SELECT * FROM users WHERE username = :username AND user = 'test'"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestApplyQueryParams_ScientificNotation(t *testing.T) {
+	params := map[string]string{"value": "1.5e-10"}
+	query := "SELECT * FROM data WHERE value = :value"
+	result := ApplyQueryParams(query, params)
+	expected := "SELECT * FROM data WHERE value = 1.5e-10"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestApplyQueryParams_NegativeNumber(t *testing.T) {
+	params := map[string]string{"value": "-42"}
+	query := "SELECT * FROM data WHERE value = :value"
+	result := ApplyQueryParams(query, params)
+	expected := "SELECT * FROM data WHERE value = -42"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestIsNumber(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"42", true},
+		{"-42", true},
+		{"3.14", true},
+		{"-3.14", true},
+		{"1e10", true},
+		{"1.5e-10", true},
+		{"1E+10", true},
+		{"", false},
+		{"abc", false},
+		{"12abc", false},
+		{"abc12", false},
+		{"-", false},
+		{".", false},
+		{"1.2.3", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := isNumber(tt.input)
+			if result != tt.expected {
+				t.Errorf("isNumber(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestQuoteValue(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"42", "42"},
+		{"3.14", "3.14"},
+		{"true", "true"},
+		{"false", "false"},
+		{"null", "null"},
+		{"NULL", "NULL"},
+		{"hello", "'hello'"},
+		{"O'Brien", "'O''Brien'"},
+		{"", "''"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := quoteValue(tt.input)
+			if result != tt.expected {
+				t.Errorf("quoteValue(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/tests/e2e/parameterized_query_test.go
+++ b/tests/e2e/parameterized_query_test.go
@@ -1,0 +1,239 @@
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParam_BasicString(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-q", "SELECT * FROM users WHERE name = :name",
+		"-p", "name=Alice",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Alice")
+	assertNotContains(t, stdout, "Bob")
+	assertNotContains(t, stdout, "Charlie")
+	assertContains(t, stdout, "(1 row")
+}
+
+func TestParam_BasicNumber(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-q", "SELECT * FROM users WHERE id = :id",
+		"-p", "id=2",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Bob")
+	assertContains(t, stdout, "(1 row")
+}
+
+func TestParam_MultipleParams(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-q", "SELECT * FROM users WHERE id >= :min_id AND id <= :max_id",
+		"-p", "min_id=1",
+		"-p", "max_id=2",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Alice")
+	assertContains(t, stdout, "Bob")
+	assertNotContains(t, stdout, "Charlie")
+	assertContains(t, stdout, "(2 rows)")
+}
+
+func TestParam_DollarSyntax(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-q", "SELECT * FROM users WHERE name = $name",
+		"-p", "name=Charlie",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Charlie")
+	assertContains(t, stdout, "(1 row")
+}
+
+func TestParam_MixedSyntax(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-q", "SELECT * FROM users WHERE id = :id OR name = $name",
+		"-p", "id=1",
+		"-p", "name=Bob",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Alice")
+	assertContains(t, stdout, "Bob")
+	assertContains(t, stdout, "(2 rows)")
+}
+
+func TestParam_StringWithSpaces(t *testing.T) {
+	// Create a temp CSV file with spaces in values
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "names.csv")
+	content := "id,full_name\n1,John Doe\n2,Jane Smith\n"
+	if err := os.WriteFile(csvPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write CSV file: %v", err)
+	}
+
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", csvPath,
+		"-q", "SELECT * FROM names WHERE full_name = :name",
+		"-p", "name=John Doe",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "John Doe")
+	assertContains(t, stdout, "(1 row")
+}
+
+func TestParam_FloatValue(t *testing.T) {
+	// Create a temp CSV file with float values
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "prices.csv")
+	content := "id,price\n1,19.99\n2,29.99\n3,39.99\n"
+	if err := os.WriteFile(csvPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write CSV file: %v", err)
+	}
+
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", csvPath,
+		"-q", "SELECT * FROM prices WHERE price < :max_price",
+		"-p", "max_price=30.00",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "19.99")
+	assertContains(t, stdout, "29.99")
+	assertNotContains(t, stdout, "39.99")
+	assertContains(t, stdout, "(2 rows)")
+}
+
+func TestParam_BooleanValue(t *testing.T) {
+	// Create a temp CSV file with boolean values
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "flags.csv")
+	content := "id,active\n1,true\n2,false\n3,true\n"
+	if err := os.WriteFile(csvPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write CSV file: %v", err)
+	}
+
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", csvPath,
+		"-q", "SELECT * FROM flags WHERE active = :active",
+		"-p", "active=true",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "(2 rows)")
+}
+
+func TestParam_WithExport(t *testing.T) {
+	tmpDir := t.TempDir()
+	exportPath := filepath.Join(tmpDir, "exported.csv")
+
+	_, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-q", "SELECT * FROM users WHERE name = :name",
+		"-p", "name=Alice",
+		"-e", exportPath,
+		"-t", "csv",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+
+	// Verify exported file
+	content, err := os.ReadFile(exportPath)
+	if err != nil {
+		t.Fatalf("Failed to read exported file: %v", err)
+	}
+	assertContains(t, string(content), "Alice")
+	assertNotContains(t, string(content), "Bob")
+}
+
+func TestParam_WithVerbose(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-q", "SELECT * FROM users WHERE id = :id",
+		"-p", "id=1",
+		"-v",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Alice")
+	// Verbose output goes to stdout
+	assertContains(t, stdout, "Parsed query parameters")
+}
+
+func TestParam_InvalidFormat(t *testing.T) {
+	_, _, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-q", "SELECT * FROM users",
+		"-p", "invalid_param")
+
+	assertError(t, err)
+}
+
+func TestParam_LikeQuery(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-q", "SELECT * FROM users WHERE name LIKE :pattern",
+		"-p", "pattern=%li%",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Alice")
+	assertContains(t, stdout, "Charlie")
+	assertNotContains(t, stdout, "Bob")
+}
+
+func TestParam_InSubquery(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/csv/users.csv",
+		"-q", "SELECT * FROM users WHERE department_id = :dept ORDER BY name",
+		"-p", "dept=10",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Alice")
+	assertContains(t, stdout, "Charlie")
+}
+
+func TestParam_NegativeNumber(t *testing.T) {
+	// Create a temp CSV file with negative values
+	tmpDir := t.TempDir()
+	csvPath := filepath.Join(tmpDir, "numbers.csv")
+	content := "id,value\n1,-10\n2,0\n3,10\n"
+	if err := os.WriteFile(csvPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write CSV file: %v", err)
+	}
+
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", csvPath,
+		"-q", "SELECT * FROM numbers WHERE value > :min",
+		"-p", "min=-5",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "0")
+	assertContains(t, stdout, "10")
+	assertContains(t, stdout, "(2 rows)")
+}
+
+func TestParam_WithJSON(t *testing.T) {
+	stdout, stderr, err := runDataQL(t, "run",
+		"-f", "tests/fixtures/json/people.json",
+		"-q", "SELECT * FROM people WHERE name = :name",
+		"-p", "name=Alice",
+		"-Q")
+
+	assertNoError(t, err, stderr)
+	assertContains(t, stdout, "Alice")
+	assertContains(t, stdout, "(1 row")
+}


### PR DESCRIPTION
## Summary

- Adds `-p/--param` flag for passing query parameters
- Supports both `:param` and `$param` syntax
- Automatic type detection for numbers, booleans, null values
- Proper SQL escaping for string values

## Usage

### Basic string parameter
```bash
dataql run -f data.csv -q "SELECT * FROM data WHERE name = :name" -p name=Alice
```

### Numeric parameter
```bash
dataql run -f data.csv -q "SELECT * FROM data WHERE id > :min" -p min=10
```

### Multiple parameters
```bash
dataql run -f data.csv \
  -q "SELECT * FROM data WHERE date BETWEEN :start AND :end AND status = :status" \
  -p start=2024-01-01 \
  -p end=2024-12-31 \
  -p status=active
```

### Dollar syntax
```bash
dataql run -f data.csv -q "SELECT * FROM data WHERE id = $id" -p id=42
```

## Features

- **Safety** - Avoids SQL injection risks in scripts
- **Readability** - Cleaner queries without string concatenation
- **Reusability** - Same query can be used with different parameters
- **Type-aware** - Numbers stay unquoted, strings are properly quoted

## Type Detection

| Value | Detected Type | Result |
|-------|--------------|--------|
| `42` | Number | `42` |
| `3.14` | Number | `3.14` |
| `-10` | Number | `-10` |
| `1.5e-10` | Number | `1.5e-10` |
| `true` | Boolean | `true` |
| `false` | Boolean | `false` |
| `null` | Null | `null` |
| `Alice` | String | `'Alice'` |
| `O'Brien` | String | `'O''Brien'` |

## Test plan
- [x] Unit tests for parameter parsing
- [x] Unit tests for parameter application
- [x] Unit tests for type detection
- [x] E2E tests for basic usage
- [x] E2E tests for multiple parameters
- [x] E2E tests for different syntaxes
- [x] E2E tests with export
- [x] E2E tests with JSON files

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)