### PR TITLE
fix(build): add build tags for noduckdb static binary builds

### DIFF
--- a/pkg/exportdata/html/export_test.go
+++ b/pkg/exportdata/html/export_test.go
@@ -1,3 +1,5 @@
+//go:build !noduckdb
+
 package html
 
 import (

--- a/pkg/exportdata/markdown/export_test.go
+++ b/pkg/exportdata/markdown/export_test.go
@@ -1,3 +1,5 @@
+//go:build !noduckdb
+
 package markdown
 
 import (

--- a/pkg/storage/duckdb/storage.go
+++ b/pkg/storage/duckdb/storage.go
@@ -1,3 +1,5 @@
+//go:build !noduckdb
+
 package duckdb
 
 import (

--- a/pkg/storage/duckdb/storage_stub.go
+++ b/pkg/storage/duckdb/storage_stub.go
@@ -1,0 +1,15 @@
+//go:build noduckdb
+
+package duckdb
+
+import (
+	"fmt"
+
+	"github.com/adrianolaselva/dataql/pkg/storage"
+)
+
+// NewDuckDBStorage returns an error when DuckDB support is not compiled in.
+// This is the stub implementation used when building with the "noduckdb" tag.
+func NewDuckDBStorage(datasource string) (storage.Storage, error) {
+	return nil, fmt.Errorf("DuckDB support is not available in this build (compiled with noduckdb tag)")
+}

--- a/pkg/storage/duckdb/storage_test.go
+++ b/pkg/storage/duckdb/storage_test.go
@@ -1,3 +1,5 @@
+//go:build !noduckdb
+
 package duckdb_test
 
 import (


### PR DESCRIPTION
## Summary

- Fixed GoReleaser pipeline failure caused by glibc/musl incompatibility when building static binaries
- Added Go build tags to properly exclude DuckDB code when building with the `noduckdb` tag
- Created stub implementation for DuckDB storage that returns an error when DuckDB is not available

## Problem

The goreleaser release pipeline was failing with errors like:
```
/root/duckdb/src/common/types/vector.cpp:22: undefined reference to `__vsnprintf_chk'
/root/duckdb/src/common/string_util.cpp:130: undefined reference to `__memcpy_chk'
```

This occurred because:
1. The DuckDB library (`libduckdb.a`) is compiled with glibc
2. The Alpine-based build container uses musl libc
3. These are not ABI-compatible for static linking

## Solution

Added `//go:build !noduckdb` build tags to files that import DuckDB:
- `pkg/storage/duckdb/storage.go`
- `pkg/storage/duckdb/storage_test.go`
- `pkg/exportdata/html/export_test.go`
- `pkg/exportdata/markdown/export_test.go`

Created `pkg/storage/duckdb/storage_stub.go` with `//go:build noduckdb` that provides stub implementation returning an error.

## Test plan

- [x] Build with `noduckdb` tag succeeds: `go build -tags noduckdb .`
- [x] Build without tag still works and tests pass
- [x] Stub correctly returns error when DuckDB is not available
- [x] All pre-commit checks pass (gofmt, golangci-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)